### PR TITLE
Also run Github Actions on pull request

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,5 @@
 name: "test-local"
-on: push
+on: [push, pull_request]
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This seems to not work yet as this PR is from a fork. According to https://docs.github.com/en/free-pro-team@latest/actions/reference/authentication-in-a-workflow#permissions-for-the-github_token you may need to create a token with the checks write permission but I don't know if this would be a security issue. EDIT: It seems like this is not currently possible so you would probably need to create a new account which just has access to this repo (which would probably be way too much effort for this). This still may be useful as it shows that it's at least working until this step (which is not optimal as the actual pushing can fail a lot of validation). I enabled actions for my fork so you could check it's checks.